### PR TITLE
[APM] Clock skew fix

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/WaterfallItem.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/WaterfallItem.tsx
@@ -116,7 +116,7 @@ export function WaterfallItem({
   }
 
   const width = (item.duration / totalDuration) * 100;
-  const left = (item.offset / totalDuration) * 100;
+  const left = ((item.offset + item.skew) / totalDuration) * 100;
   const Label = item.docType === 'transaction' ? TransactionLabel : SpanLabel;
 
   return (

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/waterfall_helpers/__snapshots__/waterfall_helpers.test.ts.snap
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/waterfall_helpers/__snapshots__/waterfall_helpers.test.ts.snap
@@ -13,6 +13,7 @@ Array [
     "name": "APIRestController#products",
     "offset": 0,
     "serviceName": "opbeans-java",
+    "skew": 0,
     "timestamp": 1536763736366000,
     "transaction": Object {},
   },
@@ -25,6 +26,7 @@ Array [
     "offset": 1000,
     "parentId": "a",
     "serviceName": "opbeans-java",
+    "skew": 0,
     "span": Object {
       "transaction": Object {
         "id": "a",
@@ -43,6 +45,7 @@ Array [
     "offset": 2000,
     "parentId": "a",
     "serviceName": "opbeans-java",
+    "skew": 0,
     "span": Object {
       "transaction": Object {
         "id": "a",
@@ -61,6 +64,7 @@ Array [
     "offset": 3000,
     "parentId": "b",
     "serviceName": "opbeans-java",
+    "skew": 0,
     "timestamp": 1536763736369000,
     "transaction": Object {},
   },
@@ -73,6 +77,7 @@ Array [
     "offset": 5000,
     "parentId": "c",
     "serviceName": "opbeans-java",
+    "skew": 0,
     "span": Object {
       "transaction": Object {
         "id": "c",

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.test.ts
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers.test.ts
@@ -4,92 +4,101 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { groupBy, indexBy } from 'lodash';
 import { Span } from 'x-pack/plugins/apm/typings/Span';
 import { Transaction } from 'x-pack/plugins/apm/typings/Transaction';
-import { getWaterfallItems, IWaterfallGroup } from './waterfall_helpers';
+import {
+  getWaterfallItems,
+  IWaterfallIndex,
+  IWaterfallItem
+} from './waterfall_helpers';
 
 describe('waterfall_helpers', () => {
   describe('getWaterfallItems', () => {
     it('should order items correctly', () => {
-      const items: IWaterfallGroup = {
-        a: [
-          {
-            id: 'b',
-            parentId: 'a',
-            serviceName: 'opbeans-java',
-            name: 'GET [0:0:0:0:0:0:0:1]',
-            duration: 4694,
-            timestamp: 1536763736368000,
-            offset: 0,
-            docType: 'span',
-            span: {
-              transaction: {
-                id: 'a'
-              }
-            } as Span
-          },
-          {
-            id: 'b2',
-            parentId: 'a',
-            serviceName: 'opbeans-java',
-            name: 'GET [0:0:0:0:0:0:0:1]',
-            duration: 4694,
-            timestamp: 1536763736367000,
-            offset: 0,
-            docType: 'span',
-            span: {
-              transaction: {
-                id: 'a'
-              }
-            } as Span
-          }
-        ],
-        b: [
-          {
-            id: 'c',
-            parentId: 'b',
-            serviceName: 'opbeans-java',
-            name: 'APIRestController#productsRemote',
-            duration: 3581,
-            timestamp: 1536763736369000,
-            offset: 0,
-            docType: 'transaction',
-            transaction: {} as Transaction
-          }
-        ],
-        c: [
-          {
-            id: 'd',
-            parentId: 'c',
-            serviceName: 'opbeans-java',
-            name: 'SELECT',
-            duration: 210,
-            timestamp: 1536763736371000,
-            offset: 0,
-            docType: 'span',
-            span: {
-              transaction: {
-                id: 'c'
-              }
-            } as Span
-          }
-        ],
-        root: [
-          {
-            id: 'a',
-            serviceName: 'opbeans-java',
-            name: 'APIRestController#products',
-            duration: 9480,
-            timestamp: 1536763736366000,
-            offset: 0,
-            docType: 'transaction',
-            transaction: {} as Transaction
-          }
-        ]
-      };
+      const items: IWaterfallItem[] = [
+        {
+          id: 'd',
+          parentId: 'c',
+          serviceName: 'opbeans-java',
+          name: 'SELECT',
+          duration: 210,
+          timestamp: 1536763736371000,
+          offset: 0,
+          skew: 0,
+          docType: 'span',
+          span: {
+            transaction: {
+              id: 'c'
+            }
+          } as Span
+        },
+        {
+          id: 'b',
+          parentId: 'a',
+          serviceName: 'opbeans-java',
+          name: 'GET [0:0:0:0:0:0:0:1]',
+          duration: 4694,
+          timestamp: 1536763736368000,
+          offset: 0,
+          skew: 0,
+          docType: 'span',
+          span: {
+            transaction: {
+              id: 'a'
+            }
+          } as Span
+        },
+        {
+          id: 'b2',
+          parentId: 'a',
+          serviceName: 'opbeans-java',
+          name: 'GET [0:0:0:0:0:0:0:1]',
+          duration: 4694,
+          timestamp: 1536763736367000,
+          offset: 0,
+          skew: 0,
+          docType: 'span',
+          span: {
+            transaction: {
+              id: 'a'
+            }
+          } as Span
+        },
+        {
+          id: 'c',
+          parentId: 'b',
+          serviceName: 'opbeans-java',
+          name: 'APIRestController#productsRemote',
+          duration: 3581,
+          timestamp: 1536763736369000,
+          offset: 0,
+          skew: 0,
+          docType: 'transaction',
+          transaction: {} as Transaction
+        },
+        {
+          id: 'a',
+          serviceName: 'opbeans-java',
+          name: 'APIRestController#products',
+          duration: 9480,
+          timestamp: 1536763736366000,
+          offset: 0,
+          skew: 0,
+          docType: 'transaction',
+          transaction: {} as Transaction
+        }
+      ];
 
-      const entryTransactionItem = items.root[0];
-      expect(getWaterfallItems(items, entryTransactionItem)).toMatchSnapshot();
+      const childrenByParentId = groupBy(
+        items,
+        hit => (hit.parentId ? hit.parentId : 'root')
+      );
+      const itemsById: IWaterfallIndex = indexBy(items, 'id');
+      const entryTransactionItem = childrenByParentId.root[0];
+      expect(
+        getWaterfallItems(childrenByParentId, itemsById, entryTransactionItem)
+      ).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
This PR implements clock skew logic, and it seems to work ok - at least for the specific case we saw with the java agent not using microseconds for transaction timestamps:

![clock skew](https://user-images.githubusercontent.com/209966/47657746-ea278700-db91-11e8-9b21-bab0f93190df.gif)


Depends on: https://github.com/elastic/kibana/pull/24651
Closes elastic/kibana#322