### PR TITLE
[APM] link to related errors list in transaction details

### DIFF
--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionProperties.tsx
@@ -17,17 +17,21 @@ import {
 import { Transaction } from '../../../../../typings/es_schemas/Transaction';
 import { NOT_AVAILABLE_LABEL } from '../../../../constants';
 import { asPercent, asTime } from '../../../../utils/formatters';
+import { KibanaLink } from '../../../shared/Links/KibanaLink';
+
 import {
   IStickyProperty,
   StickyProperties
 } from '../../../shared/StickyProperties';
 
-interface Props {
+export interface Props {
+  errorCount?: number | null;
   transaction: Transaction;
   totalDuration?: number;
 }
 
 export function StickyTransactionProperties({
+  errorCount,
   transaction,
   totalDuration
 }: Props) {
@@ -90,6 +94,29 @@ export function StickyTransactionProperties({
       width: '25%'
     }
   ];
+
+  if (errorCount) {
+    stickyProperties.push({
+      label: i18n.translate('xpack.apm.transactionDetails.errorsLabel', {
+        defaultMessage: 'Errors'
+      }),
+      val: (
+        <KibanaLink
+          pathname={'/app/apm'}
+          hash={`/${idx(transaction, _ => _.service.name)}/errors`}
+          query={{
+            kuery: `transaction.id~3A~22${transaction.transaction.id}~22`
+          }}
+        >
+          {i18n.translate('xpack.apm.transactionDetails.viewErrors', {
+            defaultMessage:
+              errorCount === 1 ? `View 1 Error` : `View ${errorCount} Errors`
+          })}
+        </KibanaLink>
+      ),
+      width: '25%'
+    });
+  }
 
   return <StickyProperties stickyProperties={stickyProperties} />;
 }

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionPropertiesErrorRequest.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/StickyTransactionPropertiesErrorRequest.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+import React from 'react';
+import { idx } from 'x-pack/plugins/apm/common/idx';
+import { IUrlParams } from 'x-pack/plugins/apm/public/store/urlParams';
+import { ErrorGroupOverviewRequest } from '../../../../store/reactReduxRequest/errorGroupList';
+import {
+  Props as IStickyTransactionPropertiesProps,
+  StickyTransactionProperties
+} from './StickyTransactionProperties';
+
+interface Props extends IStickyTransactionPropertiesProps {
+  urlParams: IUrlParams;
+}
+
+export const StickyTransactionPropertiesErrorRequest: React.SFC<Props> = ({
+  transaction,
+  urlParams: { errorGroupId, start, end },
+  ...restProps
+}) => {
+  return (
+    <ErrorGroupOverviewRequest
+      urlParams={{
+        kuery: `transaction.id: "${transaction.transaction.id}"`,
+        serviceName: idx(transaction, _ => _.service.name),
+        start,
+        end,
+        errorGroupId
+      }}
+      render={({ data }) => (
+        <StickyTransactionProperties
+          {...restProps}
+          errorCount={(data && data.length) || 0}
+          transaction={transaction}
+        />
+      )}
+    />
+  );
+};

--- a/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/TransactionDetails/Transaction/index.tsx
@@ -20,7 +20,7 @@ import { Transaction as ITransaction } from '../../../../../typings/es_schemas/T
 import { IUrlParams } from '../../../../store/urlParams';
 import { TransactionActionMenu } from '../../../shared/TransactionActionMenu/TransactionActionMenu';
 import { TransactionLink } from '../../../shared/TransactionLink';
-import { StickyTransactionProperties } from './StickyTransactionProperties';
+import { StickyTransactionPropertiesErrorRequest } from './StickyTransactionPropertiesErrorRequest';
 import { TransactionPropertiesTable } from './TransactionPropertiesTable';
 import { IWaterfall } from './WaterfallContainer/Waterfall/waterfall_helpers/waterfall_helpers';
 
@@ -139,9 +139,10 @@ export const Transaction: React.SFC<Props> = ({
 
       <EuiSpacer />
 
-      <StickyTransactionProperties
+      <StickyTransactionPropertiesErrorRequest
         transaction={transaction}
         totalDuration={waterfall.traceRootDuration}
+        urlParams={urlParams}
       />
 
       <EuiSpacer />


### PR DESCRIPTION
Fixes #21920 by adding link to related errors list by filtering with the Kuery bar

![transaction-view-related-errors](https://user-images.githubusercontent.com/1967266/51657339-5af3fa80-1f59-11e9-8348-2d1991c0b5eb.gif)
